### PR TITLE
Remove browserify fork reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "async": "~0.9.0",
-    "browserify": "strongloop-forks/node-browserify",
+    "browserify": "^9.0.3",
     "compression": "^1.0.3",
     "debug": "~2.1.1",
     "engine.io": "~1.5.1",
@@ -22,8 +22,8 @@
     "request": "~2.51.0",
     "serve-favicon": "^2.0.1",
     "shelljs": "^0.3.0",
-    "strong-pm": "^1.0.0",
-    "strong-nginx-controller": "~1.0.0"
+    "strong-nginx-controller": "~1.0.0",
+    "strong-pm": "^1.0.0"
   },
   "optionalDependencies": {
     "loopback-explorer": "^1.1.0"


### PR DESCRIPTION
Browserify has since fixed the issue causing us to fork and change their version of dependencies. This means we can remove the dependency on our fork.