### PR TITLE
Fix app always being null in manager host

### DIFF
--- a/proxy/boot/manager-host.js
+++ b/proxy/boot/manager-host.js
@@ -96,11 +96,15 @@ module.exports = function setupHooks(server) {
         return cb(err);
       }
 
-      if(inst.applicationName && inst.npmModules) {
+      if(inst.applicationName) {
         host.app = {
           name: inst.applicationName,
-          version: inst.npmModules.version
-        }
+          version: null
+        };
+      }
+
+      if(inst.npmModules) {
+        host.app.version = inst.npmModules.version;
       }
 
       request({


### PR DESCRIPTION
Change the model behaviour to still show the app name, even if the app
version is unknown.

related to strong-arc #1129