### PR TITLE
deps: hoist jsonstream dependency of browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "strong-nginx-controller": "^1.0.0"
   },
   "optionalDependencies": {
+    "jsonstream": "^1.0.3",
     "loopback-explorer": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Work around a problem caused by JSONStream and jsonstream both existing
on npmjs.org.

This is more targeted than strongloop/strongloop#220