### PR TITLE
Fix error handler and intermittent test crash

### DIFF
--- a/proxy/boot/manager-host.js
+++ b/proxy/boot/manager-host.js
@@ -34,7 +34,7 @@ module.exports = function setupHooks(server) {
     var timer;
     ManagerHost.sync(function(firstErr) {
       if(firstErr) {
-        return cb ? cb(err) : null;
+        return cb ? cb(firstErr) : null;
       }
       timer = setInterval(function() {
         ManagerHost.sync(function(err) {

--- a/test/manager-host.test.js
+++ b/test/manager-host.test.js
@@ -9,6 +9,7 @@ var createSandbox = helpers.createSandbox;
 var removeSandBox = helpers.removeSandBox;
 var deployTo = helpers.deployTo;
 var sleep = helpers.sleep;
+var proxyServer = require('../proxy/server');
 
 var testPM = {
   host: 'localhost',
@@ -29,10 +30,11 @@ describe('ManagerHost', function () {
   var lastStarted;
 
   beforeEach(function (done) {
+    var configPath = path.join(SANDBOX, 'config.json');
     createSandbox();
     lastStarted = process.hrtime();
     this.pm = createPM(0);
-    var proxy = this.proxy = require('../proxy/server')(path.join(SANDBOX, 'config.json'));
+    var proxy = this.proxy = proxyServer(configPath, {}, console.error);
     this.ManagerHost = proxy.models.ManagerHost;
     done();
   });


### PR DESCRIPTION
First commit fixes an obvious typo, second one provides a callback to the proxy server that `console.error()`s the error instead of using the default handler which just throws.