### PR TITLE
example: fix incorrect pm pid checking

### DIFF
--- a/examples/setup-pm.sh
+++ b/examples/setup-pm.sh
@@ -1,3 +1,3 @@
 cd sample-app
 cat pm.pid | xargs kill
-slc pm --listen $PM_PORT & echo $$ > pm.pid
+slc pm --listen $PM_PORT & echo $! > pm.pid


### PR DESCRIPTION
In bash, $$ is the pid of the current shell, and $! is the pid of the
most recently backgrounded job. We want the job, not the pid of the
shell we are running in.. unless we _want_ zombies..