### PR TITLE
Fix dependency timing issue in the install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "jshint .",
     "test": "mocha",
-    "install": "node proxy/build-client.js",
+    "postinstall": "node proxy/build-client.js",
     "rebuild-client": "node proxy/build-client.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "debug": "^2.1.1",
     "engine.io": "^1.5.1",
     "errorhandler": "^1.1.1",
+    "lodash": "^4.16.1",
     "loopback": "^2.8.0",
     "loopback-boot": "^2.4.0",
     "loopback-datasource-juggler": "^2.7.0",
@@ -45,6 +46,9 @@
     "strong-deploy": "^1.1.0",
     "strong-pm": "^3.0.0"
   },
+  "bundledDependencies": [
+    "lodash"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/strongloop/strong-mesh-client.git"


### PR DESCRIPTION
1) Move build-client to postinstall hook 

When running on npm@3, the postinstall hook is guaranteed to run only after all dependencies are installed. Which is needed since build-client is using quite few of our dependencies.

2) Bundle lodash dependency from strong-globalize

This is a speculative fix to avoid the following `npm install` failure that's triggered for certain timing of the order in which dependencies are installed:

```
> strong-mesh-client@1.6.3 install
> /mnt/jenkins/workspace/strong-arc/e13f9a50/node_modules/strong-mesh-client
> node proxy/build-client.js

module.js:327
    throw err;
    ^

Error: Cannot find module 'lodash/_MapCache'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous>
(/mnt/jenkins/workspace/strong-arc/e13f9a50/node_modules/loopback-boot/node_modules/strong-globalize/lib/globalize.js:14:16)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
```

Connect to #50 

@rmg or @sam-github please review