### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "loopback-boot": "^2.4.0",
     "loopback-datasource-juggler": "^2.7.0",
     "minifyify": "^6.3.2",
-    "node-uuid": "^1.4.2",
     "primus": "^2.4.12",
     "request": "^2.51.0",
     "serve-favicon": "^2.0.1",
     "strong-mesh-models": "^8.0.0",
-    "strong-nginx-controller": "^1.0.0"
+    "strong-nginx-controller": "^1.0.0",
+    "uuid": "^3.0.0"
   },
   "optionalDependencies": {
     "JSONStream": "^1.0.3",

--- a/proxy/boot/manager-host.js
+++ b/proxy/boot/manager-host.js
@@ -4,7 +4,7 @@
 // restricted by GSA ADP Schedule Contract with IBM Corp.
 
 module.exports = function setupHooks(server) {
-  var uuid = require('node-uuid');
+  var uuid = require('uuid');
   var url = require('url');
   var request = require('request');
   var ManagerHost = server.models.ManagerHost;


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.