### PR TITLE
omit 'ajv' module from browser bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - "4"
+  - "6"
+  - "7"

--- a/proxy/build-client.js
+++ b/proxy/build-client.js
@@ -97,6 +97,7 @@ function buildBrowserBundle(out, sourceMapUrl, callback) {
   // Include mesh-models, exclude non-browser requirements
   b.require(path.join(meshModelsDir,'index.js'), { expose: 'strong-mesh-models' });
   var nonBrowserReq = [
+    'ajv', // optional and unused component of request >=2.80.0
     'minkelite', 'compression', 'concat-stream', 'errorhandler', 'sprintf',
     'loopback-explorer', 'osenv', 'posix-getopt', 'serve-favicon', 'user-home',
     'strong-npm-ls', 'strong-tunnel', 'http-auth'


### PR DESCRIPTION
This is a deep dependency of 'request' that provides functionality which
is not used by this package. It is also what pulls in the troublesome
'regenerator', 'nodent', and 'js-beautify' dependencies that are the
cause of #53.

Forward port of #58.